### PR TITLE
Tweaks

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+- use PDL::FFTW3's new ability to take PDL::Complex inputs
+
+0.015 2021-03-12
 - convert from bundled Fortran code to PDL::LinearAlgebra
 
 0.014 2020-03-26
@@ -20,7 +23,7 @@
   - New directories: NPhase.
   - NPhase/OneH
   - NPhase/AllH
-  - Change Pod to new OneH ALlH
+  - Change Pod to new OneH AllH
   - Allow complex Haydock coefficients in new codes.
   - Added NPhase/EpsL
   - Added NPhase/EpsTensor

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -35,7 +35,7 @@ WriteMakefile(
 	'PDL::Lite'                      => '0',
 	'PDL::MatrixOps'                 => '0',
 	'PDL::NiceSlice'                 => '0',
-	'PDL::FFTW3'                     => '0',
+	'PDL::FFTW3'                     => '0.10', # accept PDL::Complex
 	'PDL::LinearAlgebra'             => '0.15', # cgtsv
 	'Storable'                       => '0',
     },

--- a/lib/Photonic/LE/NP/OneH.pm
+++ b/lib/Photonic/LE/NP/OneH.pm
@@ -149,7 +149,7 @@ Returns zero, as there is no need to change sign.
 
 =item * _firstState
 
-Returns the fisrt state.
+Returns the first state.
 
 =back
 

--- a/lib/Photonic/LE/NP/OneH.pm
+++ b/lib/Photonic/LE/NP/OneH.pm
@@ -212,17 +212,14 @@ sub applyOperator {
     #the result is complex ri:nx:ny...:i cartesian
     #Take inverse Fourier transform over all space dimensions,
     #thread over cartesian indices
-    #Notice that (i)fftn wants a real 2,nx,ny... piddle, not a complex
-    #one. Thus, I have to convert complex to real and back here and
-    #downwards.
-    my $Gpsi_R=ifftn($Gpsi_G->real, $self->ndims)->complex;
+    my $Gpsi_R=ifftn($Gpsi_G, $self->ndims)->complex;
     # $Gpsi_R is ri:nx:ny:...:i
     # Multiply by the dielectric function in Real Space. Thread
     # cartesian index
     my $eGpsi_R=$self->epsilon*$Gpsi_R; #Epsilon could be tensorial!
     # $eGpsi_R is ri:nx:ny...:i
     #Transform to reciprocal space
-    my $eGpsi_G=fftn($eGpsi_R->real, $self->ndims)->complex;
+    my $eGpsi_G=fftn($eGpsi_R, $self->ndims)->complex;
     # $eGpsi_G is ri:nx:ny:...:i
     #Scalar product with Gnorm
     my $GeGpsi_G=($eGpsi_G*$self->GNorm->mv(0,-1)) #^Ge^G|psi>

--- a/lib/Photonic/LE/NR2/Field.pm
+++ b/lib/Photonic/LE/NR2/Field.pm
@@ -223,7 +223,7 @@ sub evaluate {
     #filter RandI for each cartesian
     $field_G *= $self->filter->(*1) if $self->has_filter;
     #get cartesian out of the way, fourier transform, put cartesian.
-    my $field_R=ifftn($field_G->mv(1,-1)->real, $ndims)->mv(-1,1)->complex;
+    my $field_R=ifftn($field_G->mv(1,-1), $ndims)->mv(-1,1)->complex;
     $field_R*=$self->nr->B->nelem; #scale to have unit macroscopic field
     #result is RorI, cartesian, nx, ny,...
     $self->_field($field_R);

--- a/lib/Photonic/LE/NR2/OneH.pm
+++ b/lib/Photonic/LE/NR2/OneH.pm
@@ -188,13 +188,13 @@ sub applyOperator {
     #Gpsi_G is ri:nx:ny...:i
     #Take inverse Fourier transform over all space dimensions,
     #thread over cartesian indices
-    my $Gpsi_R=ifftn($Gpsi_G->real, $self->ndims)->complex; #real space ^G|psi>
+    my $Gpsi_R=ifftn($Gpsi_G, $self->ndims)->complex; #real space ^G|psi>
     #Gpsi_R is ri:nx:ny:...:i
     #Multiply by characteristic function. Thread cartesian
     my $BGpsi_R=$Gpsi_R*$self->B; #B^G|psi> in Real Space
     #BGpsi_R is ri:nx:ny:...:i
     #Transform to reciprocal space
-    my $BGpsi_G=fftn($BGpsi_R->real, $self->ndims)->complex; #<G|B^G|psi>
+    my $BGpsi_G=fftn($BGpsi_R, $self->ndims)->complex; #<G|B^G|psi>
     #BGpsi_G is ri:nx:ny:...:i
     #Scalar product with Gnorm
     my $GBGpsi_G=($BGpsi_G*$self->GNorm->mv(0,-1)) #^GB^G|psi>

--- a/lib/Photonic/LE/NR2/OneH.pm
+++ b/lib/Photonic/LE/NR2/OneH.pm
@@ -143,7 +143,7 @@ Return 0, as there is no need to change sign.
 
 item * _firstState
 
-Returns the fisrt state $v.
+Returns the first state $v.
 
 =back
 

--- a/lib/Photonic/LE/NR2/SH.pm
+++ b/lib/Photonic/LE/NR2/SH.pm
@@ -365,7 +365,7 @@ sub _build_dipolar {
     my $Esquare_R=Cmul($field, $field)->sumover;
     #Fourier transform
     # RorI nx ny...
-    my $Esquare_G=fftn($Esquare_R->real, $ndims)->complex;
+    my $Esquare_G=fftn($Esquare_R, $ndims)->complex;
     #cartesian, nx, ny...
     my $G=$self->nrf->nr->G;
     #RorI cartesian nx ny
@@ -374,7 +374,7 @@ sub _build_dipolar {
     my $iGE2=Cmul($iG, $Esquare_G->(,*1));
     #back to real space. Get cartesian out of the way and then back
     #RorI, cartesian, nx, ny...
-    my $nablaE2=ifftn($iGE2->mv(1,-1)->real, $ndims)->mv(-1,1)->complex;
+    my $nablaE2=ifftn($iGE2->mv(1,-1), $ndims)->mv(-1,1)->complex;
     my $factor=-$self->density*$self->alpha1*$self->alpha2/2;
        #RorI, nx, ny...
     my $P=$factor->(,*1)*$nablaE2;
@@ -396,7 +396,7 @@ sub _build_quadrupolar {
     #Fourier transform
     # RorI cartesian cartesian nx ny... Get cartesians out of the way
     # and thread
-    my $naaEE_G=fftn($naaEE_R->mv(1,-1)->mv(1,-1)->real,
+    my $naaEE_G=fftn($naaEE_R->mv(1,-1)->mv(1,-1),
 			$ndims)->mv(-1,1)->mv(-1,1)->complex;
     #cartesian, nx, ny...
     my $G=$self->nrf->nr->G;
@@ -411,7 +411,7 @@ sub _build_quadrupolar {
     #back to real space. Get cartesian out of the way and then back
     #RorI, cartesian, nx, ny...
     my $P=
-	ifftn($iGnaaEE_G->mv(1,-1)->real, $ndims)->mv(-1,1)->complex;
+	ifftn($iGnaaEE_G->mv(1,-1), $ndims)->mv(-1,1)->complex;
     return $P;
 }
 

--- a/lib/Photonic/LE/S/Field.pm
+++ b/lib/Photonic/LE/S/Field.pm
@@ -219,7 +219,7 @@ sub evaluate {
     #filter RandI for each cartesian
     $Esp *= $self->filter->(*1) if $self->has_filter;
     #get cartesian out of the way, fourier transform, put cartesian.
-    my $field_R=ifftn($Esp->mv(1,-1)->real, $ndims)->mv(-1,1)->complex;
+    my $field_R=ifftn($Esp->mv(1,-1), $ndims)->mv(-1,1)->complex;
     $field_R*=$self->nr->B->nelem; #scale to have unit macroscopic field
     #result is ri,xy,nx,ny,...
     $self->_field($field_R);

--- a/lib/Photonic/LE/S/OneH.pm
+++ b/lib/Photonic/LE/S/OneH.pm
@@ -151,7 +151,7 @@ Returns 0, as there is no need to change sign.
 
 =item * _firstState
 
-Returns the fisrt state.
+Returns the first state.
 
 =back
 

--- a/lib/Photonic/LE/S/OneH.pm
+++ b/lib/Photonic/LE/S/OneH.pm
@@ -214,11 +214,8 @@ sub applyOperator {
     # is the same.
     #Take inverse Fourier transform over all space dimensions,
     #thread over cartesian and pmk indices
-    #Notice that (i)fftn wants a real 2,nx,ny... piddle, not a complex
-    #one. Thus, I have to convert complex to real and back here and
-    #downwards.
     #real space ^G|psi>
-    my $Gpsi_R=ifftn($Gpsi_G->real, $self->ndims)->complex;
+    my $Gpsi_R=ifftn($Gpsi_G, $self->ndims)->complex;
     # $Gpsi_R is ri:nx:ny...i:pmk
     # $self->epsilon is ri:nx:ny...
     #Multiply by the dielectric function in Real Space. Thread
@@ -226,7 +223,7 @@ sub applyOperator {
     my $eGpsi_R=$self->epsilon*$Gpsi_R; #Epsilon could be tensorial!
     #$eGpsi_R is ri:nx:ny,...i:pmk
     #Transform to reciprocal space
-    my $eGpsi_G=fftn($eGpsi_R->real, $self->ndims)->complex->mv(-1,1);
+    my $eGpsi_G=fftn($eGpsi_R, $self->ndims)->complex->mv(-1,1);
     #$eGpsi_G is ri:pmk:nx:ny...:i
     #Scalar product with pmGnorm: i:pm:nx:ny...
     my $GeGpsi_G=($eGpsi_G*$self->pmGNorm->mv(0,-1)) #^Ge^G|psi>

--- a/lib/Photonic/WE/R2/Field.pm
+++ b/lib/Photonic/WE/R2/Field.pm
@@ -211,7 +211,7 @@ sub evaluate {
     ##filter RandI for each cartesian
     $Es *= $self->filter->(*1) if $self->has_filter;
     ##get cartesian out of the way, fourier transform, put cartesian.
-    my $field_R=ifftn($Es->mv(1,-1)->real, $ndims)->mv(-1,1)->complex;
+    my $field_R=ifftn($Es->mv(1,-1), $ndims)->mv(-1,1)->complex;
     $field_R*=$self->nr->B->nelem; #scale to have unit macroscopic field
     #result is RorI, cartesian, nx, ny,...
     $self->_field($field_R);

--- a/lib/Photonic/WE/R2/OneH.pm
+++ b/lib/Photonic/WE/R2/OneH.pm
@@ -259,7 +259,7 @@ Returns 1 if sign change is required to ensure b^2 is positive.
 
 =item *  _firstState
 
-Returns the fisrt state $v.
+Returns the first state $v.
 
 =back
 

--- a/lib/Photonic/WE/S/Field.pm
+++ b/lib/Photonic/WE/S/Field.pm
@@ -221,7 +221,7 @@ sub evaluate {
     ##filter RandI for each cartesian
     $Esp *= $self->filter->(*1) if $self->has_filter;
     ##get cartesian out of the way, fourier transform, put cartesian.
-    my $field_R=ifftn($Esp->mv(1,-1)->real, $ndims)->mv(-1,1)->complex;
+    my $field_R=ifftn($Esp->mv(1,-1), $ndims)->mv(-1,1)->complex;
     $field_R*=$self->nr->B->nelem; #scale to have unit macroscopic field
     #result is ri,xy,nx,ny...
     $self->_field($field_R);

--- a/lib/Photonic/WE/S/OneH.pm
+++ b/lib/Photonic/WE/S/OneH.pm
@@ -217,7 +217,7 @@ sub applyOperator {
     my $H=($self->epsilonR-$self->epsilon)/$self->epsilonR;
     my $Hgpsi_r=$H*$gpsi_r; #ri:nx:ny:xy:pm
     #Transform to reciprocal space, move xy and pm back and make complex,
-    my $psi_G=fftn($Hgpsi_r->real, $self->ndims)->mv(-1,1)->mv(-1,1)->complex;
+    my $psi_G=fftn($Hgpsi_r, $self->ndims)->mv(-1,1)->mv(-1,1)->complex;
     #Apply mask
     #psi_G is ri:xy:pm:nx:ny mask is nx:ny
     $psi_G=$psi_G*$mask->(*1,*1) if defined $mask; #use dummies for xy:pm

--- a/lib/Photonic/WE/S/OneH.pm
+++ b/lib/Photonic/WE/S/OneH.pm
@@ -131,7 +131,7 @@ Returns 0, as there is no need to change sign.
 
 =item * $s= _firstState($self)
 
-Returns the fisrt state $v.
+Returns the first state $v.
 
 =back
 


### PR DESCRIPTION
As part 0 of making PDL::FFTW3 handle native complex data, I made it handle PDL::Complex objects (just released as 0.08 - took until version 0.10 to get it right). This means your code doesn't need to call `->real` anymore. It may not immediately pass CI if 0.08 takes a while to be visible, but I'll keep prodding the CI till it shows up.

**Edited to add**: with version 0.10 it has now passed.

I also added the release date of 0.015 in `Changes`, hope that's Ok.