### PR TITLE
Fix complex, and tests

### DIFF
--- a/lib/Photonic/WE/R2/Green.pm
+++ b/lib/Photonic/WE/R2/Green.pm
@@ -218,7 +218,7 @@ sub _build_greenTensor {
        *$cpairs->(:,*1)
        *$greenTensor)->sumover->sumover
       ;
-    $asy *= PDL->i();
+    $asy *= PDL::Core::i();
     $asy -= $asy->transpose;
     $greenTensor+$asy;
 }

--- a/lib/Photonic/WE/ST/Green.pm
+++ b/lib/Photonic/WE/ST/Green.pm
@@ -191,7 +191,7 @@ sub _build_greenTensor {
        *$cpairs->(:,*1)
        *$symmetric)->sumover->sumover
       ;
-    $asy *= PDL->i();
+    $asy *= PDL::Core::i();
     # This is wrong: $asy -= $asy->transpose;
     $asy = $asy-$asy->transpose;
     $symmetric+$asy;

--- a/t/field-lenr2.t
+++ b/t/field-lenr2.t
@@ -146,7 +146,7 @@ $expected = pdl(<<'EOF');
  [ [ 0 -6.4125149e-17-7.2553859e-18i ] ]
 ]
 EOF
-ok(Cagree($got, $expected, 1e-33), "external_G") or diag "got: $got\nexpected: $expected";
+ok(Cagree($got, $expected, 1e-15), "external_G") or diag "got: $got\nexpected: $expected";
 # SH ext. longitudinal polarization in reciprocal space
 $got=$nrsh->externalL_G;
 $expected = pdl(<<'EOF');
@@ -164,7 +164,7 @@ $expected = pdl(<<'EOF');
  [ 6.4125149e-17+7.2553859e-18i ]
 ]
 EOF
-ok(Cagree($got, $expected, 1e-33), "externalL_G") or diag "got: $got\nexpected: $expected";
+ok(Cagree($got, $expected, 1e-15), "externalL_G") or diag "got: $got\nexpected: $expected";
 # SH ext. longitudinal polarization proj. in recip. space
 $got=$nrsh->externalVecL_G;
 $expected = pdl(<<'EOF');
@@ -182,7 +182,7 @@ $expected = pdl(<<'EOF');
  [ [ 0 -6.4125149e-17-7.2553859e-18i ] ]
 ]
 EOF
-ok(Cagree($got, $expected, 1e-33), "externalVecL_G") or diag "got: $got\nexpected: $expected";
+ok(Cagree($got, $expected, 1e-15), "externalVecL_G") or diag "got: $got\nexpected: $expected";
 # SH ext. longitudinal polarization proj. in real space'
 $got=$nrsh->externalVecL;
 $expected = pdl(<<'EOF');
@@ -200,7 +200,7 @@ $expected = pdl(<<'EOF');
  [ [ 0  3.9327802e-18-5.6182574e-19i ] ]
 ]
 EOF
-ok(Cagree($got, $expected, 1e-33), "externalVecL") or diag "got: $got\nexpected: $expected";
+ok(Cagree($got, $expected, 1e-15), "externalVecL") or diag "got: $got\nexpected: $expected";
 # SH ext. longitudinal polarization in Haydock representation
 $got=$nrsh->externalL_n;
 $expected = pdl(<<'EOF');
@@ -209,7 +209,7 @@ $expected = pdl(<<'EOF');
  0
 ]
 EOF
-ok(Cagree($got, $expected, 1e-33), "externalL_n") or diag "got: $got\nexpected: $expected";
+ok(Cagree($got, $expected, 1e-15), "externalL_n") or diag "got: $got\nexpected: $expected";
 # SH self consistent longitudinal polarization in Haydock representation
 $got=$nrsh->selfConsistentL_G;
 $expected = pdl(<<'EOF');
@@ -227,7 +227,7 @@ $expected = pdl(<<'EOF');
  [ -4.4470906e-20-3.1472783e-18i ]
 ]
 EOF
-ok(Cagree($got, $expected, 1e-35), "selfConsistentL_G") or diag "got: $got\nexpected: $expected";
+ok(Cagree($got, $expected, 1e-15), "selfConsistentL_G") or diag "got: $got\nexpected: $expected";
 # SH self consistent longitudinal polarization components in reciprocal space
 $got=$nrsh->selfConsistentVecL_G;
 $expected = pdl(<<'EOF');
@@ -245,7 +245,7 @@ $expected = pdl(<<'EOF');
  [ [ 0 4.4470906e-20+3.1472783e-18i ] ]
 ]
 EOF
-ok(Cagree($got, $expected, 1e-35), "selfConsistentVecL_G") or diag "got: $got\nexpected: $expected";
+ok(Cagree($got, $expected, 1e-15), "selfConsistentVecL_G") or diag "got: $got\nexpected: $expected";
 # SH self consistent longitudinal polarization vector field in real space
 $got=$nrsh->selfConsistentVecL;
 $expected = pdl(<<'EOF');
@@ -263,7 +263,7 @@ $expected = pdl(<<'EOF');
  [ [ 0 -1.1542169e-19-2.2366796e-19i ] ]
 ]
 EOF
-ok(Cagree($got, $expected, 1e-35), "selfConsistentVecL") or diag "got: $got\nexpected: $expected";
+ok(Cagree($got, $expected, 1e-15), "selfConsistentVecL") or diag "got: $got\nexpected: $expected";
 # Linear "atomic" polarizability
 $got=$nrsh->alpha1;
 $expected = pdl(<<'EOF');


### PR DESCRIPTION
The next version of PDL will have `i` be strictly a constant. This will mean that `PDL->i`, as used in two of your newer modules, will stop working (and already does in our downstream CI testing). The idiom of `PDL::Core::i()` works in both the old and the new scheme, which one of the commits implements.

On my MacBook, some tests in `t/field-lenr2.t` are using a very high precison (1e-33 and 1e-35). My machine's `machine_precision` is only 1e-16, and those tests fail. The other commit dials that precision down to 1e-15, which seems appropriate, and would also (I believe) fix #26. I added the various tests with high precision because I needed to be sure that changing from PDL::Complex to native-complex would work *exactly the same*, i.e. I hadn't broken anything. That does not mean I chose the correct numbers. Please @wlmb (or really, anyone who understands the physics here better than me), could you look at the inputs for those various tests, and tell me if (as I now suspect) theory says they're supposed to just calculate to zero? If so, I can adjust the tests to be much clearer.

Another change that I haven't made here, but will be pleased to if you'd like it, is to update the tests to use Test::PDL, which these days is incorporated into main PDL.

If these changes here are seen as beneficial, **it would help me a lot if you could merge them and release the distro to CPAN**, so that I can make the rest of the change to PDL.